### PR TITLE
rvalue-only object streaming to Message

### DIFF
--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -111,8 +111,12 @@ class GTEST_API_ Message {
   }
 #else
   // Streams a non-pointer value to this object.
-  template <typename T>
-  inline Message& operator <<(const T& val) {
+  //
+  // We use perfect-forwarding here so that objects which can only be
+  // streamed as rvalue-references work.
+  template <typename T,
+    typename std::enable_if<!std::is_pointer<T>::value, int>::type = 0>
+  inline Message& operator <<(T&& val) {
     // Some libraries overload << for STL containers.  These
     // overloads are defined in the global namespace instead of ::std.
     //
@@ -128,7 +132,7 @@ class GTEST_API_ Message {
     // overloads of << defined in the global namespace and those
     // visible via Koenig lookup are both exposed in this function.
     using ::operator <<;
-    *ss_ << val;
+    *ss_ << std::forward<T>(val);
     return *this;
   }
 


### PR DESCRIPTION
Some objects are designed to exist only as temporaries while a single statement is evaluated. They typically capture constructor parameters by reference and do other things which are not safe for long-lived objects.

One way to make it more difficult for these objects to be used incorrectly is to define all the public methods/operators/etc such that only `&&` and `const&&` parameters are permitted. In this case the expected streaming operator declaration for such a `Type` is `std::ostream& operator<<(std::ostream&, Type const&&)`.

This change allows such objects to be used with googletest Message objects.